### PR TITLE
enable optional zeroconf for airplay and chomecast plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM mono:5
 ENV TINI_VERSION=0.18.0
 ENV LANG=en_US.UTF-8
 ENV HOMESEER_VERSION=3_0_0_435
+ENV ZEROCONF_ENABLED=NO
 
 RUN apt-get update && apt-get install -y \
     chromium \
     flite \
     wget \
+    avahi-daemon \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/start.sh
+++ b/start.sh
@@ -14,4 +14,10 @@ else
 
 fi
 
+if [ "$ZEROCONF_ENABLED" = "TRUE" ]
+then 
+    service dbus start
+    service avahi-daemon start
+fi
+
 mono /HomeSeer/HSConsole.exe --log


### PR DESCRIPTION
docker file amended to install avahi daemon and set environment variable ENABLE_ZEROCONF=NO
this will install needed compoents but ensure ZEROCONF is not enabled by default (folks hate boradcast things).

By changing the env var this can be enabled,

startup script amedend to run daemon and dbus service on prescense of ENABLE_ZEROCONF=TRUE

Note, i am not a coder (literally) i had to look up IF usage to make this work. i did this a)because i hate not trying to contribute and b)to lear about vscode and github - feel free to reject,

Note 2 the avahi service depends on dbus - i think this is already present in the docker image?

